### PR TITLE
speed up lm_pd.fit

### DIFF
--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -172,8 +172,8 @@ pd_lm.fit <- function(y, X,
   }
     
   y_na <- is.na(y)
-  Xo <- X[!y_na, , drop = FALSE]
-  Xm <- X[y_na, , drop = FALSE]
+  Xo <- X[!y_na, , drop=FALSE]
+  Xm <- X[y_na, , drop=FALSE]
   yo <- y[!y_na]
   p <- ncol(X)
   n <- nrow(X)
@@ -186,14 +186,14 @@ pd_lm.fit <- function(y, X,
     
   ## create initial value for beta
   if (moderate_location) {
-    beta_init <- c(location_prior_mean, rep(0, times = p - 1))
+    beta_init <- c(location_prior_mean, rep(0, times=p-1))
   } else if (length(yo) == 0) {
-    beta_init <- rep(0, times = p)
+    beta_init <- rep(0, times=p)
   } else {
     if (has_intercept(X)) {
-      beta_init <- c(mean(yo), rep(0, times = p - 1))
+      beta_init <- c(mean(yo), rep(0, times=p-1))
     } else {
-      beta_init <- rep(mean(yo), times = p)
+      beta_init <- rep(mean(yo), times=p)
     }
   }
     
@@ -209,10 +209,10 @@ pd_lm.fit <- function(y, X,
   fit_beta <- rep(NA, p)
   names(fit_beta) <- colnames(X)
     
-  failed_result <- list(coefficients = rep(NA, p),
-                        coef_variance_matrix = matrix(NA, nrow = p, ncol = p),
-                        correction_factor = matrix(NA, nrow = p, ncol = p),
-                        n_approx = NA, df = NA, s2 = NA, n_obs = length(yo))
+  failed_result <- list(coefficients=rep(NA, p),
+                        coef_variance_matrix=matrix(NA, nrow=p, ncol=p),
+                        correction_factor=matrix(NA, nrow=p, ncol=p),
+                        n_approx=NA, df=NA, s2=NA, n_obs=length(yo))
     
   if (all_observed && !moderate_variance && !moderate_location) {
     ## Run lm if there are no missing values
@@ -244,7 +244,7 @@ pd_lm.fit <- function(y, X,
     }
         
     fit_beta <- opt_res$par[beta_sel]
-    coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
+    coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop=FALSE]
     fit_sigma2 <- opt_res$par[p+1]
     fit_sigma2_var <- 1/opt_res$hessian[p+1, p+1]
       
@@ -278,7 +278,7 @@ pd_lm.fit <- function(y, X,
     }
           
     fit_beta <- opt_res$par[beta_sel]
-    coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
+    coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop=FALSE]
     fit_sigma2 <- opt_res$par[p+1]
     fit_sigma2_var <- 1/opt_res$hessian[p+1, p+1]
       
@@ -331,7 +331,7 @@ pd_lm.fit <- function(y, X,
                           location_prior_df, moderate_location, moderate_variance,
                           beta_sel, p)
     fit_sigma2_var <- 1/hessian[p+1, p+1]
-    coef_hessian <- hessian[beta_sel, beta_sel, drop = FALSE]
+    coef_hessian <- hessian[beta_sel, beta_sel, drop=FALSE]
   }
     
   if (fit_sigma2_var < 0){

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -393,25 +393,25 @@ pd_lm.fit <- function(y, X,
   names(fit_beta) <- colnames(Var_coef_unbiased) <- 
     rownames(Var_coef_unbiased) <- colnames(X)
     
-  list(coefficients = fit_beta,
-       coef_variance_matrix = Var_coef_unbiased,
-       correction_factor = Correction_Factor,
-       n_approx = n_approx, df = df_approx,
-       s2 = s2_approx,
-       n_obs = length(yo))
+  list(coefficients=fit_beta,
+       coef_variance_matrix=Var_coef_unbiased,
+       correction_factor=Correction_Factor,
+       n_approx=n_approx, df=df_approx,
+       s2=s2_approx,
+       n_obs=length(yo))
 }
 
 objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance) {
   val <- 0
   if (moderate_location) {
-    val <- sum(dt.scaled(X %*% beta, df = location_prior_df, mean = mu0, sd = sqrt(sigma20), log = TRUE))
+    val <- sum(dt.scaled(X %*% beta, df=location_prior_df, mean=mu0, sd=sqrt(sigma20), log=TRUE))
   }
   if (moderate_variance) {
-    val <- val + extraDistr::dinvchisq(sigma2, df0, tau20, log = TRUE) + log(sigma2)
+    val <- val + extraDistr::dinvchisq(sigma2, df0, tau20, log=TRUE) + log(sigma2)
   }
   val + 
-    sum(dnorm(Xo %*% beta, yo, sd = sqrt(sigma2), log = TRUE)) + 
-    sum(invprobit(Xm %*% beta, rho, zetastar, log = TRUE))
+    sum(dnorm(Xo %*% beta, yo, sd=sqrt(sigma2), log=TRUE)) + 
+    sum(invprobit(Xm %*% beta, rho, zetastar, log=TRUE))
 }
 
 grad_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance) {
@@ -457,7 +457,7 @@ hess_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20
     if (moderate_location) {
       Xbm <- (X %*% beta - mu0)^2
       t_prior_fact <- (location_prior_df * sigma20 - Xbm)/(location_prior_df * sigma20 + Xbm)^2
-      dbb_p <- -(location_prior_df + 1) * t(X) %*% diag(t_prior_fact, nrow = nrow(X)) %*% X
+      dbb_p <- -(location_prior_df + 1) * t(X) %*% diag(t_prior_fact, nrow=nrow(X)) %*% X
     } else {
       dbb_p <- 0
     }
@@ -475,7 +475,7 @@ hess_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20
     dbs_o <- t(Xo) %*% X0by0/sigma2^2
     dbs_m <- t(Xm) %*% (Xmbr/(2 * zetastar_2) * imr^2 - (zetastar_2 - Xmbr^2)/(2 * zetastar_4) * imr)
   
-    res <- matrix(NA, nrow = q, ncol = q)
+    res <- matrix(NA, nrow=q, ncol=q)
     res[beta_sel, beta_sel] <- dbb_p + dbb_o + dbb_m
     res[q, q] <- dss_p + dss_o + dss_m
     res[q, beta_sel] <- res[beta_sel, q] <- dbs_o + dbs_m
@@ -487,7 +487,7 @@ has_intercept <- function(X){
 
   any(vapply(seq_len(ncol(X)), function(idx){
     all(X[, idx] == 1)
-  }, FUN.VALUE = FALSE))
+  }, FUN.VALUE=FALSE))
 
 }
 
@@ -495,7 +495,7 @@ has_intercept <- function(X){
 
 calculate_skew_correction_factors <- function(y, yo, X, Xm, Xo, fit_beta, fit_sigma2, Var_coef, rho, zetastar,
                                              mu0, sigma20, df0, tau20, location_prior_df,
-                                             moderate_location, moderate_variance, out_factor = 2){
+                                             moderate_location, moderate_variance, out_factor=2){
   p <- length(fit_beta)
   res <- vapply(seq_len(p), function(idx){
     if(any(is.na(fit_beta))){

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -179,7 +179,7 @@ pd_lm.fit <- function(y, X,
   n <- nrow(X)
     
   all_observed <- all(!y_na)
-  all_missing <- !all_observed ##all(y_na)
+  all_missing <- all(y_na)
     
   rho <- dropout_curve_position[y_na]
   zeta <- dropout_curve_scale[y_na]
@@ -438,7 +438,7 @@ grad_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20
     
   dsig2_o <- sum(((Xo %*% beta - yo)^2 - sigma2)/(2 * sigma2^2))
   dsig2_m <- -sum((Xm %*% beta - rho)/(2 * zetastar^2) * imr)
-  dbeta_p + dbeta_o + dbeta_m, dsig2_p + dsig2_o + dsig2_m
+  c(dbeta_p + dbeta_o + dbeta_m, dsig2_p + dsig2_o + dsig2_m)
 }
 
 
@@ -451,12 +451,13 @@ hess_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20
     zetastar_2 <- zetastar^2
     zetastar_4 <- zetastar_2^2
     Xmbr <- Xm %*% beta - rho
-    X0by0 <- Xo %*% beta - yo
+    Xoby0 <- Xo %*% beta - yo
     q <- p+1
       
     if (moderate_location) {
       Xbm <- (X %*% beta - mu0)^2
-      t_prior_fact <- (location_prior_df * sigma20 - Xbm)/(location_prior_df * sigma20 + Xbm)^2
+      t_prior_fact <- c((location_prior_df * sigma20 - Xbm)/
+            (location_prior_df * sigma20 + Xbm)^2)
       dbb_p <- -(location_prior_df + 1) * t(X) %*% diag(t_prior_fact, nrow=nrow(X)) %*% X
     } else {
       dbb_p <- 0
@@ -472,7 +473,7 @@ hess_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20
     dss_o <- sum((sigma2 - 2 * Xoby0^2)/(2 * sigma2^3))
     dss_m <- sum(Xmbr/(4 * zetastar_4) * imr * (3 - Xmbr * imr - Xmbr^2/zetastar_2))
   
-    dbs_o <- t(Xo) %*% X0by0/sigma2^2
+    dbs_o <- t(Xo) %*% Xoby0/sigma2^2
     dbs_m <- t(Xm) %*% (Xmbr/(2 * zetastar_2) * imr^2 - (zetastar_2 - Xmbr^2)/(2 * zetastar_4) * imr)
   
     res <- matrix(NA, nrow=q, ncol=q)

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -199,7 +199,7 @@ pd_lm.fit <- function(y, X,
     
   ## create initial value for sigma2
   if (moderate_variance) {
-    sigma2_init <- variance_prior_df * variance_prior_scale / (variance_prior_df + 2)
+    sigma2_init <- variance_prior_df * variance_prior_scale/(variance_prior_df + 2)
   } else {
     sigma2_init <- 1
   }
@@ -218,9 +218,9 @@ pd_lm.fit <- function(y, X,
     ## Run lm if there are no missing values
     lm_res <- lm(yo ~ Xo - 1)
     fit_beta <- coefficients(lm_res)
-    fit_sigma2 <- summary(lm_res)$sigma ^ 2 * (n - p) / n
-    coef_hessian <-  1 / fit_sigma2 * (t(X) %*% X)
-    fit_sigma2_var <- 2 * fit_sigma2 ^ 2 / n
+    fit_sigma2 <- summary(lm_res)$sigma^2 * (n - p)/n
+    coef_hessian <-  1/fit_sigma2 * (t(X) %*% X)
+    fit_sigma2_var <- 2 * fit_sigma2^2/n
       
   } else if (all_missing && !moderate_variance) {
     return(failed_result)
@@ -230,12 +230,12 @@ pd_lm.fit <- function(y, X,
       beta <- par[beta_sel]
       sigma2 <- par[p+1]
       if (sigma2 <= 0) return (10000)
-        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-        - objective_fnc(y, yo, X, Xm, Xo,
-                        beta, sigma2, rho, zetastar,
-                        location_prior_mean, location_prior_scale,
-                        variance_prior_df, variance_prior_scale,
-                        location_prior_df, moderate_location, moderate_variance)
+      zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
+      - objective_fnc(y, yo, X, Xm, Xo,
+                      beta, sigma2, rho, zetastar,
+                      location_prior_mean, location_prior_scale,
+                      variance_prior_df, variance_prior_scale,
+                      location_prior_df, moderate_location, moderate_variance)
     },
     method = "Nelder-Mead", hessian = TRUE)
       
@@ -246,7 +246,7 @@ pd_lm.fit <- function(y, X,
     fit_beta <- opt_res$par[beta_sel]
     coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
     fit_sigma2 <- opt_res$par[p+1]
-    fit_sigma2_var <- 1 / opt_res$hessian[p+1, p+1]
+    fit_sigma2_var <- 1/opt_res$hessian[p+1, p+1]
       
   } else if (method == "analytic_grad") {
     # Run optim
@@ -254,7 +254,7 @@ pd_lm.fit <- function(y, X,
       beta <- par[beta_sel]
       sigma2 <- par[p+1]
       if (sigma2 <= 0) return(10000)
-      zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+      zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
       - objective_fnc(y, yo, X, Xm, Xo,
                       beta, sigma2, rho, zetastar,
                       location_prior_mean, location_prior_scale,
@@ -265,22 +265,22 @@ pd_lm.fit <- function(y, X,
       beta <- par[beta_sel]
       sigma2 <- par[p+1]
       if (sigma2 <= 0) return(10000)
-      zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+      zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
       - grad_fnc(y, yo, X, Xm, Xo,
                  beta, sigma2, rho, zetastar,
                  location_prior_mean, location_prior_scale,
                  variance_prior_df, variance_prior_scale,
                  location_prior_df, moderate_location, moderate_variance)
-      }, method = "BFGS", hessian=TRUE)
+    }, method = "BFGS", hessian=TRUE)
             
-      if (opt_res$convergence != 0) {
-        return(failed_result)
-      }
+    if (opt_res$convergence != 0) {
+      return(failed_result)
+    }
           
-      fit_beta <- opt_res$par[beta_sel]
-      coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
-      fit_sigma2 <- opt_res$par[p+1]
-      fit_sigma2_var <- 1 / opt_res$hessian[p+1, p+1]
+    fit_beta <- opt_res$par[beta_sel]
+    coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
+    fit_sigma2 <- opt_res$par[p+1]
+    fit_sigma2_var <- 1/opt_res$hessian[p+1, p+1]
       
   } else if (method == "analytic_hessian") {
     ## Run nlminb
@@ -288,7 +288,7 @@ pd_lm.fit <- function(y, X,
       objective = function(par) {
         beta <- par[beta_sel]
         sigma2 <- par[p+1]
-        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+        zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
         - objective_fnc(y, yo, X, Xm, Xo,
                         beta, sigma2, rho, zetastar,
                         location_prior_mean, location_prior_scale,
@@ -298,7 +298,7 @@ pd_lm.fit <- function(y, X,
       gradient = function(par) {
         beta <- par[beta_sel]
         sigma2 <- par[p+1]
-        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+        zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
         - grad_fnc(y, yo, X, Xm, Xo,
                    beta, sigma2, rho, zetastar,
                    location_prior_mean, location_prior_scale,
@@ -308,7 +308,7 @@ pd_lm.fit <- function(y, X,
       hessian = function(par) {
         beta <- par[beta_sel]
         sigma2 <- par[p+1]
-        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+        zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
         - hess_fnc(y, yo, X, Xm, Xo,
                    beta, sigma2, rho, zetastar,
                    location_prior_mean, location_prior_scale,
@@ -323,14 +323,14 @@ pd_lm.fit <- function(y, X,
       
     fit_beta <- nl_res$par[beta_sel]
     fit_sigma2 <- nl_res$par[p+1]
-    zetastar <- zeta * sqrt(1 + fit_sigma2 / zeta ^ 2)
+    zetastar <- zeta * sqrt(1 + fit_sigma2/zeta^2)
     hessian <- - hess_fnc(y, yo, X, Xm, Xo,
                           fit_beta, fit_sigma2, rho, zetastar,
                           location_prior_mean, location_prior_scale,
                           variance_prior_df, variance_prior_scale,
                           location_prior_df, moderate_location, moderate_variance,
                           beta_sel, p)
-    fit_sigma2_var <- 1 / hessian[p+1, p+1]
+    fit_sigma2_var <- 1/hessian[p+1, p+1]
     coef_hessian <- hessian[beta_sel, beta_sel, drop = FALSE]
   }
     
@@ -350,7 +350,7 @@ pd_lm.fit <- function(y, X,
   # Calculate correction factor for skew
   # the skew means that the fit is bad on both sides. We only care about the
   # right side, so we will calculate a factor that improves that one
-  zetastar <- zeta * sqrt(1 + fit_sigma2 / zeta ^ 2)
+  zetastar <- zeta * sqrt(1 + fit_sigma2/zeta^2)
   Correction_Factor <- calculate_skew_correction_factors(y, yo, X, Xm, Xo,
                                       fit_beta, fit_sigma2, Var_coef, rho, zetastar, 
                                       location_prior_mean, location_prior_scale, 
@@ -420,24 +420,24 @@ grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma2
 
   if (moderate_location) {
     Xbmu <- X %*% beta - mu0
-    dbeta_p <- -(location_prior_df + 1) * t(X) %*%(Xbmu / (location_prior_df * sigma20 + Xbmu^2))
+    dbeta_p <- -(location_prior_df + 1) * t(X) %*%(Xbmu/(location_prior_df * sigma20 + Xbmu^2))
   } else {
     dbeta_p <- 0
   }
   
   Xo_t <- t(Xo)
-  dbeta_o <- -(Xo_t %*% Xo %*% beta - Xo_t %*% yo) / sigma2
+  dbeta_o <- -(Xo_t %*% Xo %*% beta - Xo_t %*% yo)/sigma2
   dbeta_m <- t(Xm) %*% imr
   
   
   if (moderate_variance) {
-    dsig2_p <- -(1 + df0 / 2) / sigma2 + df0 * tau20 / (2 * sigma2 ^ 2) + 1 / sigma2
+    dsig2_p <- -(1 + df0/2)/sigma2 + df0 * tau20/(2 * sigma2^2) + 1/sigma2
   } else {
     dsig2_p <- 0
   }
     
-  dsig2_o <- sum(((Xo %*% beta - yo) ^ 2 - sigma2) / (2 * sigma2 ^ 2))
-  dsig2_m <- -sum((Xm %*% beta - rho)/(2 * zetastar ^ 2) * imr)
+  dsig2_o <- sum(((Xo %*% beta - yo)^2 - sigma2)/(2 * sigma2^2))
+  dsig2_m <- -sum((Xm %*% beta - rho)/(2 * zetastar^2) * imr)
   dbeta_p + dbeta_o + dbeta_m, dsig2_p + dsig2_o + dsig2_m
 }
 
@@ -448,32 +448,32 @@ hess_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20
   imr <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
     
   ## precalculate values
-  zetastar_2 <- zetastar ^ 2
-  zetastar_4 <- zetastar_2 ^ 2
+  zetastar_2 <- zetastar^2
+  zetastar_4 <- zetastar_2^2
   Xmbr <- Xm %*% beta - rho
   X0by0 <- Xo %*% beta - yo
   q <- p+1
     
   if (moderate_location) {
-    Xbm <- (X %*% beta - mu0) ^ 2
-    t_prior_fact <- (location_prior_df * sigma20 - Xbm) / (location_prior_df * sigma20 + Xbm) ^ 2
+    Xbm <- (X %*% beta - mu0)^2
+    t_prior_fact <- (location_prior_df * sigma20 - Xbm)/(location_prior_df * sigma20 + Xbm)^2
     dbb_p <- -(location_prior_df + 1) * t(X) %*% diag(t_prior_fact, nrow = nrow(X)) %*% X
   } else {
     dbb_p <- 0
   }
-  dbb_o <- -2 * t(Xo) %*% Xo / (2 * sigma2)
-  dbb_m <- - t(Xm) %*% diag(c((imr ^ 2 + Xmbr / zetastar_2 * imr)), nrow(Xm)) %*% Xm
+  dbb_o <- -2 * t(Xo) %*% Xo/(2 * sigma2)
+  dbb_m <- - t(Xm) %*% diag(c((imr^2 + Xmbr/zetastar_2 * imr)), nrow(Xm)) %*% Xm
 
   if (moderate_variance) {
-    dss_p <- (1 + df0 / 2)/ (sigma2 ^ 2) - df0 * tau20 / (sigma2 ^ 3) - 1 / sigma2 ^ 2
+    dss_p <- (1 + df0/2)/ (sigma2^2) - df0 * tau20/(sigma2^3) - 1/sigma2^2
   } else {
     dss_p <- 0
   }
-  dss_o <- sum((sigma2 - 2 * Xoby0 ^ 2) / (2 * sigma2 ^ 3))
-  dss_m <- sum(Xmbr / (4 * zetastar_4) * imr * (3 - Xmbr * imr - Xmbr ^ 2 / zetastar_2))
+  dss_o <- sum((sigma2 - 2 * Xoby0^2)/(2 * sigma2^3))
+  dss_m <- sum(Xmbr/(4 * zetastar_4) * imr * (3 - Xmbr * imr - Xmbr^2/zetastar_2))
 
-  dbs_o <- t(Xo) %*% X0by0 / sigma2 ^ 2
-  dbs_m <- t(Xm) %*% (Xmbr / (2 * zetastar_2) * imr ^ 2 - (zetastar_2 - Xmbr^2) / (2 * zetastar_4) * imr)
+  dbs_o <- t(Xo) %*% X0by0/sigma2^2
+  dbs_m <- t(Xm) %*% (Xmbr/(2 * zetastar_2) * imr^2 - (zetastar_2 - Xmbr^2)/(2 * zetastar_4) * imr)
 
   res <- matrix(NA, nrow = q, ncol = q)
   res[beta_sel, beta_sel] <- dbb_p + dbb_o + dbb_m
@@ -549,7 +549,7 @@ calculate_skew_correction_factors <- function(y, yo, X, Xm, Xo, fit_beta, fit_si
                             moderate_location = moderate_location,
                             moderate_variance = moderate_variance)
 
-      (abs(diff - offset) / (out_factor / 2))^(-1)
+      (abs(diff - offset)/(out_factor/2))^(-1)
     }
   }, FUN.VALUE = 0.0)
 
@@ -586,9 +586,9 @@ calculate_sigma2_parameters <- function(fit_sigma2, fit_sigma2_var,
                                         variance_prior_scale, variance_prior_df,
                                         moderate_variance, n, p){
 
-  n_approx <- 2 * fit_sigma2^2 / fit_sigma2_var
-  rss_approx <- 2 * fit_sigma2^3 / fit_sigma2_var
-  s2_approx <- rss_approx / (n_approx - p)
+  n_approx <- 2 * fit_sigma2^2/fit_sigma2_var
+  rss_approx <- 2 * fit_sigma2^3/fit_sigma2_var
+  s2_approx <- rss_approx/(n_approx - p)
 
   if(s2_approx < 0 || n_approx <= p){
     df_approx <- 1e-3

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -210,9 +210,9 @@ pd_lm.fit <- function(y, X,
   names(fit_beta) <- colnames(X)
     
   failed_result <- list(coefficients = rep(NA, p),
-    coef_variance_matrix = matrix(NA, nrow = p, ncol = p),
-    correction_factor = matrix(NA, nrow = p, ncol = p),
-    n_approx = NA, df = NA, s2 = NA, n_obs = length(yo))
+                        coef_variance_matrix = matrix(NA, nrow = p, ncol = p),
+                        correction_factor = matrix(NA, nrow = p, ncol = p),
+                        n_approx = NA, df = NA, s2 = NA, n_obs = length(yo))
     
   if (all_observed && !moderate_variance && !moderate_location) {
     ## Run lm if there are no missing values
@@ -231,11 +231,11 @@ pd_lm.fit <- function(y, X,
       sigma2 <- par[p + 1]
       if (sigma2 <= 0) return (10000)
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-        -objective_fnc(y, yo, X, Xm, Xo,
-          beta, sigma2, rho, zetastar,
-          location_prior_mean, location_prior_scale,
-          variance_prior_df, variance_prior_scale,
-          location_prior_df, moderate_location, moderate_variance)
+        - objective_fnc(y, yo, X, Xm, Xo,
+                        beta, sigma2, rho, zetastar,
+                        location_prior_mean, location_prior_scale,
+                        variance_prior_df, variance_prior_scale,
+                        location_prior_df, moderate_location, moderate_variance)
     },
     method = "Nelder-Mead", hessian = TRUE)
       
@@ -255,22 +255,22 @@ pd_lm.fit <- function(y, X,
         sigma2 <- par[p + 1]
         if (sigma2 <= 0) return(10000)
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-        -objective_fnc(y, yo, X, Xm, Xo,
-                       beta, sigma2, rho, zetastar,
-                       location_prior_mean, location_prior_scale,
-                       variance_prior_df, variance_prior_scale,
-                       location_prior_df, moderate_location, moderate_variance)
+        - objective_fnc(y, yo, X, Xm, Xo,
+                        beta, sigma2, rho, zetastar,
+                        location_prior_mean, location_prior_scale,
+                        variance_prior_df, variance_prior_scale,
+                        location_prior_df, moderate_location, moderate_variance)
     },
     gr = function(par) {
       beta <- par[beta_sel]
       sigma2 <- par[p + 1]
       if (sigma2 <= 0) return(10000)
       zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-      -grad_fnc(y, yo, X, Xm, Xo,
-                beta, sigma2, rho, zetastar,
-                location_prior_mean, location_prior_scale,
-                variance_prior_df, variance_prior_scale,
-                location_prior_df, moderate_location, moderate_variance)
+      - grad_fnc(y, yo, X, Xm, Xo,
+                 beta, sigma2, rho, zetastar,
+                 location_prior_mean, location_prior_scale,
+                 variance_prior_df, variance_prior_scale,
+                 location_prior_df, moderate_location, moderate_variance)
       }, method = "BFGS", hessian=TRUE)
             
       if (opt_res$convergence != 0) {
@@ -289,32 +289,32 @@ pd_lm.fit <- function(y, X,
         beta <- par[beta_sel]
         sigma2 <- par[p + 1]
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-        -objective_fnc(y, yo, X, Xm, Xo,
-                       beta, sigma2, rho, zetastar,
-                       location_prior_mean, location_prior_scale,
-                       variance_prior_df, variance_prior_scale,
-                       location_prior_df, moderate_location, moderate_variance)
+        - objective_fnc(y, yo, X, Xm, Xo,
+                        beta, sigma2, rho, zetastar,
+                        location_prior_mean, location_prior_scale,
+                        variance_prior_df, variance_prior_scale,
+                        location_prior_df, moderate_location, moderate_variance)
       },
       gradient = function(par) {
         beta <- par[beta_sel]
         sigma2 <- par[p + 1]
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-        -grad_fnc(y, yo, X, Xm, Xo,
-                  beta, sigma2, rho, zetastar,
-                  location_prior_mean, location_prior_scale,
-                  variance_prior_df, variance_prior_scale,
-                  location_prior_df, moderate_location, moderate_variance)
+        - grad_fnc(y, yo, X, Xm, Xo,
+                   beta, sigma2, rho, zetastar,
+                   location_prior_mean, location_prior_scale,
+                   variance_prior_df, variance_prior_scale,
+                   location_prior_df, moderate_location, moderate_variance)
       },
       hessian = function(par) {
         beta <- par[beta_sel]
         sigma2 <- par[p + 1]
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-        -hess_fnc(y, yo, X, Xm, Xo,
-                  beta, sigma2, rho, zetastar,
-                  location_prior_mean, location_prior_scale,
-                  variance_prior_df, variance_prior_scale,
-                  location_prior_df, moderate_location, moderate_variance,
-                  beta_sel, p)
+        - hess_fnc(y, yo, X, Xm, Xo,
+                   beta, sigma2, rho, zetastar,
+                   location_prior_mean, location_prior_scale,
+                   variance_prior_df, variance_prior_scale,
+                   location_prior_df, moderate_location, moderate_variance,
+                   beta_sel, p)
     }, lower= c(rep(-Inf, length(beta_init)), 0))
         
     if (nl_res$convergence != 0) {
@@ -324,12 +324,12 @@ pd_lm.fit <- function(y, X,
     fit_beta <- nl_res$par[beta_sel]
     fit_sigma2 <- nl_res$par[p + 1]
     zetastar <- zeta * sqrt(1 + fit_sigma2 / zeta ^ 2)
-    hessian <- -hess_fnc(y, yo, X, Xm, Xo,
-                         fit_beta, fit_sigma2, rho, zetastar,
-                         location_prior_mean, location_prior_scale,
-                         variance_prior_df, variance_prior_scale,
-                         location_prior_df, moderate_location, moderate_variance,
-                         beta_sel, p)
+    hessian <- - hess_fnc(y, yo, X, Xm, Xo,
+                          fit_beta, fit_sigma2, rho, zetastar,
+                          location_prior_mean, location_prior_scale,
+                          variance_prior_df, variance_prior_scale,
+                          location_prior_df, moderate_location, moderate_variance,
+                          beta_sel, p)
     fit_sigma2_var <- 1 / hessian[p + 1, p + 1]
     coef_hessian <- hessian[beta_sel, beta_sel, drop = FALSE]
   }
@@ -358,10 +358,12 @@ pd_lm.fit <- function(y, X,
     
   # Correct Var_coef to make it unbiased
   # Plugging unbiased s2_approx into Hessian calculation
-  hessian <- - hess_fnc(y, yo, X, Xm, Xo, fit_beta, s2_approx, rho, zetastar,
-    location_prior_mean, location_prior_scale, variance_prior_df, 
-    variance_prior_scale, location_prior_df, moderate_location, 
-    moderate_variance, beta_sel, p)
+  hessian <- - hess_fnc(y, yo, X, Xm, Xo, 
+                        fit_beta, s2_approx, rho, zetastar,
+                        location_prior_mean, location_prior_scale, 
+                        variance_prior_df, variance_prior_scale, 
+                        location_prior_df, moderate_location, 
+                        moderate_variance, beta_sel, p)
   coef_hessian <- hessian[beta_sel, beta_sel, drop = FALSE]
     
   ## Set hessian to zero, so that the variances become infinite when one
@@ -390,11 +392,11 @@ pd_lm.fit <- function(y, X,
     rownames(Var_coef_unbiased) <- colnames(X)
     
   list(coefficients = fit_beta,
-    coef_variance_matrix = Var_coef_unbiased,
-    correction_factor = Correction_Factor,
-    n_approx = n_approx, df = df_approx,
-    s2 = s2_approx,
-    n_obs = length(yo))
+       coef_variance_matrix = Var_coef_unbiased,
+       correction_factor = Correction_Factor,
+       n_approx = n_approx, df = df_approx,
+       s2 = s2_approx,
+       n_obs = length(yo))
 }
 
 objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, 

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -243,158 +243,158 @@ pd_lm.fit <- function(y, X,
       return(failed_result)
     }
         
-        fit_beta <- opt_res$par[beta_sel]
-        coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
-        fit_sigma2 <- opt_res$par[p + 1]
-        fit_sigma2_var <- 1 / opt_res$hessian[p + 1, p + 1]
+    fit_beta <- opt_res$par[beta_sel]
+    coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
+    fit_sigma2 <- opt_res$par[p + 1]
+    fit_sigma2_var <- 1 / opt_res$hessian[p + 1, p + 1]
       
-    } else if (method == "analytic_grad") {
-        # Run optim
-        opt_res <- stats::optim(par = c(beta_init, sigma2_init), function(par) {
-            beta <- par[beta_sel]
-            sigma2 <- par[p + 1]
-            if (sigma2 <= 0) return(10000)
-            zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-            -objective_fnc(y, yo, X, Xm, Xo,
+  } else if (method == "analytic_grad") {
+    # Run optim
+    opt_res <- stats::optim(par = c(beta_init, sigma2_init), function(par) {
+        beta <- par[beta_sel]
+        sigma2 <- par[p + 1]
+        if (sigma2 <= 0) return(10000)
+        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+        -objective_fnc(y, yo, X, Xm, Xo,
+                       beta, sigma2, rho, zetastar,
+                       location_prior_mean, location_prior_scale,
+                       variance_prior_df, variance_prior_scale,
+                       location_prior_df, moderate_location, moderate_variance)
+    },
+    gr = function(par) {
+      beta <- par[beta_sel]
+      sigma2 <- par[p + 1]
+      if (sigma2 <= 0) return(10000)
+      zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+      -grad_fnc(y, yo, X, Xm, Xo,
                 beta, sigma2, rho, zetastar,
                 location_prior_mean, location_prior_scale,
                 variance_prior_df, variance_prior_scale,
                 location_prior_df, moderate_location, moderate_variance)
-            },
-            gr = function(par) {
-                beta <- par[beta_sel]
-                sigma2 <- par[p + 1]
-                if (sigma2 <= 0) return(10000)
-                zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-                -grad_fnc(y, yo, X, Xm, Xo,
-                    beta, sigma2, rho, zetastar,
-                    location_prior_mean, location_prior_scale,
-                    variance_prior_df, variance_prior_scale,
-                    location_prior_df, moderate_location, moderate_variance)
-            }, method = "BFGS", hessian=TRUE)
+      }, method = "BFGS", hessian=TRUE)
             
-            if (opt_res$convergence != 0) {
-                return(failed_result)
-            }
+      if (opt_res$convergence != 0) {
+        return(failed_result)
+      }
           
-            fit_beta <- opt_res$par[beta_sel]
-            coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
-            fit_sigma2 <- opt_res$par[p + 1]
-            fit_sigma2_var <- 1 / opt_res$hessian[p + 1, p + 1]
+      fit_beta <- opt_res$par[beta_sel]
+      coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
+      fit_sigma2 <- opt_res$par[p + 1]
+      fit_sigma2_var <- 1 / opt_res$hessian[p + 1, p + 1]
       
-    } else if (method == "analytic_hessian") {
-        ## Run nlminb
-        nl_res <- nlminb(start = c(beta_init, sigma2_init),
-            objective = function(par) {
-                beta <- par[beta_sel]
-                sigma2 <- par[p + 1]
-                zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-                -objective_fnc(y, yo, X, Xm, Xo,
-                    beta, sigma2, rho, zetastar,
-                    location_prior_mean, location_prior_scale,
-                    variance_prior_df, variance_prior_scale,
-                    location_prior_df, moderate_location, moderate_variance)
-            },
-            gradient = function(par) {
-                beta <- par[beta_sel]
-                sigma2 <- par[p + 1]
-                zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-                -grad_fnc(y, yo, X, Xm, Xo,
-                    beta, sigma2, rho, zetastar,
-                    location_prior_mean, location_prior_scale,
-                    variance_prior_df, variance_prior_scale,
-                    location_prior_df, moderate_location, moderate_variance)
-            },
-            hessian = function(par) {
-                beta <- par[beta_sel]
-                sigma2 <- par[p + 1]
-                zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-                -hess_fnc(y, yo, X, Xm, Xo,
-                    beta, sigma2, rho, zetastar,
-                    location_prior_mean, location_prior_scale,
-                    variance_prior_df, variance_prior_scale,
-                    location_prior_df, moderate_location, moderate_variance,
-                    beta_sel, p)
-        }, lower= c(rep(-Inf, length(beta_init)), 0))
+  } else if (method == "analytic_hessian") {
+    ## Run nlminb
+    nl_res <- nlminb(start = c(beta_init, sigma2_init),
+      objective = function(par) {
+        beta <- par[beta_sel]
+        sigma2 <- par[p + 1]
+        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+        -objective_fnc(y, yo, X, Xm, Xo,
+                       beta, sigma2, rho, zetastar,
+                       location_prior_mean, location_prior_scale,
+                       variance_prior_df, variance_prior_scale,
+                       location_prior_df, moderate_location, moderate_variance)
+      },
+      gradient = function(par) {
+        beta <- par[beta_sel]
+        sigma2 <- par[p + 1]
+        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+        -grad_fnc(y, yo, X, Xm, Xo,
+                  beta, sigma2, rho, zetastar,
+                  location_prior_mean, location_prior_scale,
+                  variance_prior_df, variance_prior_scale,
+                  location_prior_df, moderate_location, moderate_variance)
+      },
+      hessian = function(par) {
+        beta <- par[beta_sel]
+        sigma2 <- par[p + 1]
+        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+        -hess_fnc(y, yo, X, Xm, Xo,
+                  beta, sigma2, rho, zetastar,
+                  location_prior_mean, location_prior_scale,
+                  variance_prior_df, variance_prior_scale,
+                  location_prior_df, moderate_location, moderate_variance,
+                  beta_sel, p)
+    }, lower= c(rep(-Inf, length(beta_init)), 0))
         
-        if (nl_res$convergence != 0) {
-            return(failed_result)
-        }
-        
-        fit_beta <- nl_res$par[beta_sel]
-        fit_sigma2 <- nl_res$par[p + 1]
-        zetastar <- zeta * sqrt(1 + fit_sigma2 / zeta ^ 2)
-        hessian <- -hess_fnc(y, yo, X, Xm, Xo,
-            fit_beta, fit_sigma2, rho, zetastar,
-            location_prior_mean, location_prior_scale,
-            variance_prior_df, variance_prior_scale,
-            location_prior_df, moderate_location, moderate_variance,
-            beta_sel, p)
-        fit_sigma2_var <- 1 / hessian[p + 1, p + 1]
-        coef_hessian <- hessian[beta_sel, beta_sel, drop = FALSE]
-    }
-    
-    if (fit_sigma2_var < 0){
+    if (nl_res$convergence != 0) {
       return(failed_result)
     }
-    
-    Var_coef <- invert_hessian_matrix(coef_hessian, p, verbose)
-    
-    # Use fitted sigma2 and associated uncertainty to estimate df and unbiased sigma2
-    sigma2_params <- calculate_sigma2_parameters(fit_sigma2, fit_sigma2_var,
-        variance_prior_scale, variance_prior_df, moderate_variance, n, p)
-    n_approx <- sigma2_params$n_approx
-    df_approx <- sigma2_params$df_approx
-    s2_approx <- sigma2_params$s2_approx
-    
-    # Calculate correction factor for skew
-    # the skew means that the fit is bad on both sides. We only care about the
-    # right side, so we will calculate a factor that improves that one
+      
+    fit_beta <- nl_res$par[beta_sel]
+    fit_sigma2 <- nl_res$par[p + 1]
     zetastar <- zeta * sqrt(1 + fit_sigma2 / zeta ^ 2)
-    Correction_Factor <- calculate_skew_correction_factors(y, yo, X, Xm, Xo,
-        fit_beta, fit_sigma2, Var_coef, rho, zetastar, location_prior_mean, 
-        location_prior_scale, variance_prior_df, variance_prior_scale,
-        location_prior_df, moderate_location, moderate_variance, out_factor = 8)
-    
-    # Correct Var_coef to make it unbiased
-    # Plugging unbiased s2_approx into Hessian calculation
-    hessian <- - hess_fnc(y, yo, X, Xm, Xo, fit_beta, s2_approx, rho, zetastar,
-        location_prior_mean, location_prior_scale, variance_prior_df, 
-        variance_prior_scale, location_prior_df, moderate_location, 
-        moderate_variance, beta_sel, p)
+    hessian <- -hess_fnc(y, yo, X, Xm, Xo,
+                         fit_beta, fit_sigma2, rho, zetastar,
+                         location_prior_mean, location_prior_scale,
+                         variance_prior_df, variance_prior_scale,
+                         location_prior_df, moderate_location, moderate_variance,
+                         beta_sel, p)
+    fit_sigma2_var <- 1 / hessian[p + 1, p + 1]
     coef_hessian <- hessian[beta_sel, beta_sel, drop = FALSE]
+  }
     
-    ## Set hessian to zero, so that the variances become infinite when one
-    ## diagonal element is negative (this is bad)
-    if (any(diag(coef_hessian) < 0)) {
-        coef_hessian <- matrix(0, nrow = p, ncol = p)
-    }
-    Var_coef_unbiased <- invert_hessian_matrix(coef_hessian, p, verbose)
+  if (fit_sigma2_var < 0){
+    return(failed_result)
+  }
     
-    ## Apply correction factor to the unbiased Var_coef
-    Var_coef_unbiased <- Correction_Factor %*% Var_coef_unbiased %*% Correction_Factor
+  Var_coef <- invert_hessian_matrix(coef_hessian, p, verbose)
     
-    ## Set estimates to NA if no reasonable inference
-    coef_should_be_inf <- diag(Var_coef) > 1e6
-    for (idx in which(coef_should_be_inf)) {
-        Var_coef_unbiased[idx, idx] <- Inf
-    }
+  # Use fitted sigma2 and associated uncertainty to estimate df and unbiased sigma2
+  sigma2_params <- calculate_sigma2_parameters(fit_sigma2, fit_sigma2_var,
+      variance_prior_scale, variance_prior_df, moderate_variance, n, p)
+  n_approx <- sigma2_params$n_approx
+  df_approx <- sigma2_params$df_approx
+  s2_approx <- sigma2_params$s2_approx
     
-    fit_beta[coef_should_be_inf] <- NA
-    if (all(coef_should_be_inf)) {
-        n_approx <- df_approx <- s2_approx <- NA
-    }
+  # Calculate correction factor for skew
+  # the skew means that the fit is bad on both sides. We only care about the
+  # right side, so we will calculate a factor that improves that one
+  zetastar <- zeta * sqrt(1 + fit_sigma2 / zeta ^ 2)
+  Correction_Factor <- calculate_skew_correction_factors(y, yo, X, Xm, Xo,
+      fit_beta, fit_sigma2, Var_coef, rho, zetastar, location_prior_mean, 
+      location_prior_scale, variance_prior_df, variance_prior_scale,
+      location_prior_df, moderate_location, moderate_variance, out_factor = 8)
     
-    # Make everything pretty and return results
-    names(fit_beta) <- colnames(Var_coef_unbiased) <- 
-        rownames(Var_coef_unbiased) <- colnames(X)
+  # Correct Var_coef to make it unbiased
+  # Plugging unbiased s2_approx into Hessian calculation
+  hessian <- - hess_fnc(y, yo, X, Xm, Xo, fit_beta, s2_approx, rho, zetastar,
+    location_prior_mean, location_prior_scale, variance_prior_df, 
+    variance_prior_scale, location_prior_df, moderate_location, 
+    moderate_variance, beta_sel, p)
+  coef_hessian <- hessian[beta_sel, beta_sel, drop = FALSE]
     
-    list(coefficients = fit_beta,
-        coef_variance_matrix = Var_coef_unbiased,
-        correction_factor = Correction_Factor,
-        n_approx = n_approx, df = df_approx,
-        s2 = s2_approx,
-        n_obs = length(yo))
+  ## Set hessian to zero, so that the variances become infinite when one
+  ## diagonal element is negative (this is bad)
+  if (any(diag(coef_hessian) < 0)) {
+      coef_hessian <- matrix(0, nrow = p, ncol = p)
+  }
+  Var_coef_unbiased <- invert_hessian_matrix(coef_hessian, p, verbose)
+    
+  ## Apply correction factor to the unbiased Var_coef
+  Var_coef_unbiased <- Correction_Factor %*% Var_coef_unbiased %*% Correction_Factor
+    
+  ## Set estimates to NA if no reasonable inference
+  coef_should_be_inf <- diag(Var_coef) > 1e6
+  for (idx in which(coef_should_be_inf)) {
+    Var_coef_unbiased[idx, idx] <- Inf
+  }
+    
+  fit_beta[coef_should_be_inf] <- NA
+  if (all(coef_should_be_inf)) {
+    n_approx <- df_approx <- s2_approx <- NA
+  }
+    
+  # Make everything pretty and return results
+  names(fit_beta) <- colnames(Var_coef_unbiased) <- 
+    rownames(Var_coef_unbiased) <- colnames(X)
+    
+  list(coefficients = fit_beta,
+    coef_variance_matrix = Var_coef_unbiased,
+    correction_factor = Correction_Factor,
+    n_approx = n_approx, df = df_approx,
+    s2 = s2_approx,
+    n_obs = length(yo))
 }
 
 objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, 

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -285,15 +285,15 @@ pd_lm.fit <- function(y, X,
   } else if (method == "analytic_hessian") {
     ## Run nlminb
     nl_res <- nlminb(start = c(beta_init, sigma2_init),
-      objective = function(par) {
-        beta <- par[beta_sel]
-        sigma2 <- par[p+1]
-        zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
-        - objective_fnc(y, yo, X, Xm, Xo,
-                        beta, sigma2, rho, zetastar,
-                        location_prior_mean, location_prior_scale,
-                        variance_prior_df, variance_prior_scale,
-                        location_prior_df, moderate_location, moderate_variance)
+       objective = function(par) {
+         beta <- par[beta_sel]
+         sigma2 <- par[p+1]
+         zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
+         - objective_fnc(y, yo, X, Xm, Xo,
+                         beta, sigma2, rho, zetastar,
+                         location_prior_mean, location_prior_scale,
+                         variance_prior_df, variance_prior_scale,
+                         location_prior_df, moderate_location, moderate_variance)
       },
       gradient = function(par) {
         beta <- par[beta_sel]
@@ -357,7 +357,7 @@ pd_lm.fit <- function(y, X,
                                       variance_prior_df, variance_prior_scale,
                                       location_prior_df, moderate_location, moderate_variance,
                                       out_factor = 8)
-    
+
   # Correct Var_coef to make it unbiased
   # Plugging unbiased s2_approx into Hessian calculation
   hessian <- - hess_fnc(y, yo, X, Xm, Xo,

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -251,15 +251,15 @@ pd_lm.fit <- function(y, X,
   } else if (method == "analytic_grad") {
     # Run optim
     opt_res <- stats::optim(par = c(beta_init, sigma2_init), function(par) {
-        beta <- par[beta_sel]
-        sigma2 <- par[p + 1]
-        if (sigma2 <= 0) return(10000)
-        zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
-        - objective_fnc(y, yo, X, Xm, Xo,
-                        beta, sigma2, rho, zetastar,
-                        location_prior_mean, location_prior_scale,
-                        variance_prior_df, variance_prior_scale,
-                        location_prior_df, moderate_location, moderate_variance)
+      beta <- par[beta_sel]
+      sigma2 <- par[p + 1]
+      if (sigma2 <= 0) return(10000)
+      zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
+      - objective_fnc(y, yo, X, Xm, Xo,
+                      beta, sigma2, rho, zetastar,
+                      location_prior_mean, location_prior_scale,
+                      variance_prior_df, variance_prior_scale,
+                      location_prior_df, moderate_location, moderate_variance)
     },
     gr = function(par) {
       beta <- par[beta_sel]
@@ -352,9 +352,11 @@ pd_lm.fit <- function(y, X,
   # right side, so we will calculate a factor that improves that one
   zetastar <- zeta * sqrt(1 + fit_sigma2 / zeta ^ 2)
   Correction_Factor <- calculate_skew_correction_factors(y, yo, X, Xm, Xo,
-      fit_beta, fit_sigma2, Var_coef, rho, zetastar, location_prior_mean, 
-      location_prior_scale, variance_prior_df, variance_prior_scale,
-      location_prior_df, moderate_location, moderate_variance, out_factor = 8)
+                                      fit_beta, fit_sigma2, Var_coef, rho, zetastar, 
+                                      location_prior_mean, location_prior_scale, 
+                                      variance_prior_df, variance_prior_scale,
+                                      location_prior_df, moderate_location, moderate_variance, 
+                                      out_factor = 8)
     
   # Correct Var_coef to make it unbiased
   # Plugging unbiased s2_approx into Hessian calculation
@@ -399,20 +401,17 @@ pd_lm.fit <- function(y, X,
        n_obs = length(yo))
 }
 
-objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, 
-    sigma20, df0, tau20, location_prior_df, moderate_location, 
-    moderate_variance) {
-    val <- 0
-    if (moderate_location) {
-        val <- sum(dt.scaled(X %*% beta, df = location_prior_df, 
-            mean = mu0, sd = sqrt(sigma20), log = TRUE))
-    }
-    if (moderate_variance) {
-        val <- val + extraDistr::dinvchisq(sigma2, df0, tau20, log = TRUE) + 
-            log(sigma2)
-    }
-    val + sum(dnorm(Xo %*% beta, yo, sd = sqrt(sigma2), log = TRUE)) + 
-        sum(invprobit(Xm %*% beta, rho, zetastar, log = TRUE))
+objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance) {
+  val <- 0
+  if (moderate_location) {
+    val <- sum(dt.scaled(X %*% beta, df = location_prior_df, mean = mu0, sd = sqrt(sigma20), log = TRUE))
+  }
+  if (moderate_variance) {
+    val <- val + extraDistr::dinvchisq(sigma2, df0, tau20, log = TRUE) + log(sigma2)
+  }
+  val + 
+    sum(dnorm(Xo %*% beta, yo, sd = sqrt(sigma2), log = TRUE)) + 
+    sum(invprobit(Xm %*% beta, rho, zetastar, log = TRUE))
 }
 
 grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, 

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -152,15 +152,15 @@ pd_lm <- function(formula, data = NULL, subset = NULL,
 #'   }
 #' @keywords internal
 pd_lm.fit <- function(y, X,
-  dropout_curve_position,
-  dropout_curve_scale,
-  location_prior_mean = NULL,
-  location_prior_scale = NULL,
-  variance_prior_scale = NULL,
-  variance_prior_df = NULL,
-  location_prior_df = 3,
-  method = c("analytic_hessian", "analytic_grad", "numeric"),
-  verbose = FALSE){
+                      dropout_curve_position,
+                      dropout_curve_scale,
+                      location_prior_mean = NULL,
+                      location_prior_scale = NULL,
+                      variance_prior_scale = NULL,
+                      variance_prior_df = NULL,
+                      location_prior_df = 3,
+                      method = c("analytic_hessian", "analytic_grad", "numeric"),
+                      verbose = FALSE){
   
   method <- match.arg(method, c("analytic_hessian", "analytic_grad", "numeric"))
     

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -411,27 +411,35 @@ objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, si
   val
 }
 
-
-grad_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance){
-  imr <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
-
-  if(moderate_location){
-    dbeta_p <-  -(location_prior_df + 1) * t(X) %*% ((X %*% beta - mu0) / (location_prior_df * sigma20 + (X %*% beta - mu0)^2))
-  }else{
-    dbeta_p <-  0
-  }
-  dbeta_o <- - (t(Xo) %*% Xo %*% beta - t(Xo) %*% yo) / sigma2
-  dbeta_m <- t(Xm) %*% imr
-
-  if(moderate_variance){
-    dsig2_p <- -(1 + df0/2) / sigma2 + df0 * tau20 / (2 * sigma2^2) + 1/sigma2
-  }else{
-    dsig2_p <- 0
-  }
-  dsig2_o <- sum(((Xo %*% beta - yo)^2 - sigma2) / (2 * sigma2^2))
-  dsig2_m <- -sum((Xm %*% beta - rho) / (2 * zetastar^2) * imr)
-
-  c(dbeta_p + dbeta_o + dbeta_m, dsig2_p + dsig2_o + dsig2_m)
+grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, 
+    sigma20, df0, tau20, location_prior_df, moderate_location, 
+    moderate_variance) {
+  
+    imr <- proDA:::inv_mills_ratio(Xm %*% beta, rho, zetastar)
+  
+    if (moderate_location) {
+        Xbmu <- X %*% beta - mu0
+        dbeta_p <- -(location_prior_df + 1) * t(X) %*% 
+            (Xbmu / (location_prior_df * sigma20 + Xbmu^2))
+    } else {
+        dbeta_p <- 0
+    }
+  
+    Xo_t <- t(Xo)
+    dbeta_o <- -(Xo_t %*% Xo %*% beta - Xo_t %*% yo) / sigma2
+    dbeta_m <- t(Xm) %*% imr
+  
+  
+    if (moderate_variance) {
+        dsig2_p <- -(1 + df0 / 2) / sigma2 + df0 * tau20 / (2 * sigma2 ^ 2) + 
+            1 / sigma2
+    } else {
+        dsig2_p <- 0
+    }
+    
+    dsig2_o <- sum(((Xo %*% beta - yo) ^ 2 - sigma2) / (2 * sigma2 ^ 2))
+    dsig2_m <- -sum((Xm %*% beta - rho)/(2 * zetastar ^ 2) * imr)
+    c(dbeta_p + dbeta_o + dbeta_m, dsig2_p + dsig2_o + dsig2_m)
 }
 
 

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -152,36 +152,36 @@ pd_lm <- function(formula, data = NULL, subset = NULL,
 #'   }
 #' @keywords internal
 pd_lm.fit <- function(y, X,
-    dropout_curve_position,
-    dropout_curve_scale,
-    location_prior_mean = NULL,
-    location_prior_scale = NULL,
-    variance_prior_scale = NULL,
-    variance_prior_df = NULL,
-    location_prior_df = 3,
-    method = c("analytic_hessian", "analytic_grad", "numeric"),
-    verbose = FALSE){
+  dropout_curve_position,
+  dropout_curve_scale,
+  location_prior_mean = NULL,
+  location_prior_scale = NULL,
+  variance_prior_scale = NULL,
+  variance_prior_df = NULL,
+  location_prior_df = 3,
+  method = c("analytic_hessian", "analytic_grad", "numeric"),
+  verbose = FALSE){
   
-    method <- match.arg(method, c("analytic_hessian", "analytic_grad", "numeric"))
+  method <- match.arg(method, c("analytic_hessian", "analytic_grad", "numeric"))
     
-    moderate_location <- !missing(location_prior_mean) && 
-        !is.null(location_prior_mean) && !is.na(location_prior_mean)
-    moderate_variance <- !missing(variance_prior_scale) && 
-        !is.null(variance_prior_scale)  && !is.na(variance_prior_scale)
+  moderate_location <- !missing(location_prior_mean) && 
+    !is.null(location_prior_mean) && !is.na(location_prior_mean)
+  moderate_variance <- !missing(variance_prior_scale) && 
+    !is.null(variance_prior_scale)  && !is.na(variance_prior_scale)
     
-    if (!moderate_location && !moderate_variance && nrow(X) < ncol(X) + 1) {
-        stop("Underdetermined system. There are more parameters to estimate than available rows.")
-    }
+  if (!moderate_location && !moderate_variance && nrow(X) < ncol(X) + 1) {
+    stop("Underdetermined system. There are more parameters to estimate than available rows.")
+  }
     
-    y_na <- is.na(y)
-    Xo <- X[!y_na, , drop = FALSE]
-    Xm <- X[y_na, , drop = FALSE]
-    yo <- y[!y_na]
-    p <- ncol(X)
-    n <- nrow(X)
+  y_na <- is.na(y)
+  Xo <- X[!y_na, , drop = FALSE]
+  Xm <- X[y_na, , drop = FALSE]
+  yo <- y[!y_na]
+  p <- ncol(X)
+  n <- nrow(X)
     
-    all_observed <- all(!y_na)
-    all_missing <- !all_observed ##all(y_na)
+  all_observed <- all(!y_na)
+  all_missing <- !all_observed ##all(y_na)
     
     rho <- dropout_curve_position[y_na]
     zeta <- dropout_curve_scale[y_na]

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -294,28 +294,28 @@ pd_lm.fit <- function(y, X,
                          location_prior_mean, location_prior_scale,
                          variance_prior_df, variance_prior_scale,
                          location_prior_df, moderate_location, moderate_variance)
-      },
-      gradient = function(par) {
-        beta <- par[beta_sel]
-        sigma2 <- par[p+1]
-        zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
-        - grad_fnc(y, yo, X, Xm, Xo,
-                   beta, sigma2, rho, zetastar,
-                   location_prior_mean, location_prior_scale,
-                   variance_prior_df, variance_prior_scale,
-                   location_prior_df, moderate_location, moderate_variance)
-      },
-      hessian = function(par) {
-        beta <- par[beta_sel]
-        sigma2 <- par[p+1]
-        zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
-        - hess_fnc(y, yo, X, Xm, Xo,
-                   beta, sigma2, rho, zetastar,
-                   location_prior_mean, location_prior_scale,
-                   variance_prior_df, variance_prior_scale,
-                   location_prior_df, moderate_location, moderate_variance,
-                   beta_sel, p)
-    }, lower= c(rep(-Inf, length(beta_init)), 0))
+       },
+       gradient = function(par) {
+         beta <- par[beta_sel]
+         sigma2 <- par[p+1]
+         zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
+         - grad_fnc(y, yo, X, Xm, Xo,
+                    beta, sigma2, rho, zetastar,
+                    location_prior_mean, location_prior_scale,
+                    variance_prior_df, variance_prior_scale,
+                    location_prior_df, moderate_location, moderate_variance)
+       },
+       hessian = function(par) {
+         beta <- par[beta_sel]
+         sigma2 <- par[p+1]
+         zetastar <- zeta * sqrt(1 + sigma2/zeta^2)
+         - hess_fnc(y, yo, X, Xm, Xo,
+                    beta, sigma2, rho, zetastar,
+                    location_prior_mean, location_prior_scale,
+                    variance_prior_df, variance_prior_scale,
+                    location_prior_df, moderate_location, moderate_variance,
+                    beta_sel, p)
+     }, lower= c(rep(-Inf, length(beta_init)), 0))
         
     if (nl_res$convergence != 0) {
       return(failed_result)

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -210,9 +210,9 @@ pd_lm.fit <- function(y, X,
   names(fit_beta) <- colnames(X)
     
   failed_result <- list(coefficients=rep(NA, p),
-                        coef_variance_matrix=matrix(NA, nrow=p, ncol=p),
-                        correction_factor=matrix(NA, nrow=p, ncol=p),
-                        n_approx=NA, df=NA, s2=NA, n_obs=length(yo))
+                        coef_variance_matrix = matrix(NA, nrow=p, ncol=p),
+                        correction_factor = matrix(NA, nrow=p, ncol=p),
+                        n_approx=NA, df=NA, s2=NA, n_obs = length(yo))
     
   if (all_observed && !moderate_variance && !moderate_location) {
     ## Run lm if there are no missing values

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -549,7 +549,7 @@ calculate_skew_correction_factors <- function(y, yo, X, Xm, Xo, fit_beta, fit_si
                             moderate_location = moderate_location,
                             moderate_variance = moderate_variance)
 
-      (abs(diff - offset)/(out_factor / 2))^(-1)
+      (abs(diff - offset) / (out_factor / 2))^(-1)
     }
   }, FUN.VALUE = 0.0)
 

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -352,15 +352,15 @@ pd_lm.fit <- function(y, X,
   # right side, so we will calculate a factor that improves that one
   zetastar <- zeta * sqrt(1 + fit_sigma2/zeta^2)
   Correction_Factor <- calculate_skew_correction_factors(y, yo, X, Xm, Xo,
-                                      fit_beta, fit_sigma2, Var_coef, rho, zetastar, 
-                                      location_prior_mean, location_prior_scale, 
+                                      fit_beta, fit_sigma2, Var_coef, rho, zetastar,
+                                      location_prior_mean, location_prior_scale,
                                       variance_prior_df, variance_prior_scale,
-                                      location_prior_df, moderate_location, moderate_variance, 
+                                      location_prior_df, moderate_location, moderate_variance,
                                       out_factor = 8)
     
   # Correct Var_coef to make it unbiased
   # Plugging unbiased s2_approx into Hessian calculation
-  hessian <- - hess_fnc(y, yo, X, Xm, Xo, 
+  hessian <- - hess_fnc(y, yo, X, Xm, Xo,
                         fit_beta, s2_approx, rho, zetastar,
                         location_prior_mean, location_prior_scale, 
                         variance_prior_df, variance_prior_scale, 
@@ -416,7 +416,7 @@ objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, si
 
 grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance) {
   
-  im r <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
+  imr <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
 
   if (moderate_location) {
     Xbmu <- X %*% beta - mu0
@@ -445,41 +445,41 @@ grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma2
 hess_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, 
                      moderate_location, moderate_variance, beta_sel, p){
     
-  imr <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
-    
-  ## precalculate values
-  zetastar_2 <- zetastar^2
-  zetastar_4 <- zetastar_2^2
-  Xmbr <- Xm %*% beta - rho
-  X0by0 <- Xo %*% beta - yo
-  q <- p+1
-    
-  if (moderate_location) {
-    Xbm <- (X %*% beta - mu0)^2
-    t_prior_fact <- (location_prior_df * sigma20 - Xbm)/(location_prior_df * sigma20 + Xbm)^2
-    dbb_p <- -(location_prior_df + 1) * t(X) %*% diag(t_prior_fact, nrow = nrow(X)) %*% X
-  } else {
-    dbb_p <- 0
-  }
-  dbb_o <- -2 * t(Xo) %*% Xo/(2 * sigma2)
-  dbb_m <- - t(Xm) %*% diag(c((imr^2 + Xmbr/zetastar_2 * imr)), nrow(Xm)) %*% Xm
-
-  if (moderate_variance) {
-    dss_p <- (1 + df0/2)/ (sigma2^2) - df0 * tau20/(sigma2^3) - 1/sigma2^2
-  } else {
-    dss_p <- 0
-  }
-  dss_o <- sum((sigma2 - 2 * Xoby0^2)/(2 * sigma2^3))
-  dss_m <- sum(Xmbr/(4 * zetastar_4) * imr * (3 - Xmbr * imr - Xmbr^2/zetastar_2))
-
-  dbs_o <- t(Xo) %*% X0by0/sigma2^2
-  dbs_m <- t(Xm) %*% (Xmbr/(2 * zetastar_2) * imr^2 - (zetastar_2 - Xmbr^2)/(2 * zetastar_4) * imr)
-
-  res <- matrix(NA, nrow = q, ncol = q)
-  res[beta_sel, beta_sel] <- dbb_p + dbb_o + dbb_m
-  res[q, q] <- dss_p + dss_o + dss_m
-  res[q, beta_sel] <- res[beta_sel, q] <- dbs_o + dbs_m
-  res
+    imr <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
+      
+    ## precalculate values
+    zetastar_2 <- zetastar^2
+    zetastar_4 <- zetastar_2^2
+    Xmbr <- Xm %*% beta - rho
+    X0by0 <- Xo %*% beta - yo
+    q <- p+1
+      
+    if (moderate_location) {
+      Xbm <- (X %*% beta - mu0)^2
+      t_prior_fact <- (location_prior_df * sigma20 - Xbm)/(location_prior_df * sigma20 + Xbm)^2
+      dbb_p <- -(location_prior_df + 1) * t(X) %*% diag(t_prior_fact, nrow = nrow(X)) %*% X
+    } else {
+      dbb_p <- 0
+    }
+    dbb_o <- -2 * t(Xo) %*% Xo/(2 * sigma2)
+    dbb_m <- - t(Xm) %*% diag(c((imr^2 + Xmbr/zetastar_2 * imr)), nrow(Xm)) %*% Xm
+  
+    if (moderate_variance) {
+      dss_p <- (1 + df0/2)/ (sigma2^2) - df0 * tau20/(sigma2^3) - 1/sigma2^2
+    } else {
+      dss_p <- 0
+    }
+    dss_o <- sum((sigma2 - 2 * Xoby0^2)/(2 * sigma2^3))
+    dss_m <- sum(Xmbr/(4 * zetastar_4) * imr * (3 - Xmbr * imr - Xmbr^2/zetastar_2))
+  
+    dbs_o <- t(Xo) %*% X0by0/sigma2^2
+    dbs_m <- t(Xm) %*% (Xmbr/(2 * zetastar_2) * imr^2 - (zetastar_2 - Xmbr^2)/(2 * zetastar_4) * imr)
+  
+    res <- matrix(NA, nrow = q, ncol = q)
+    res[beta_sel, beta_sel] <- dbb_p + dbb_o + dbb_m
+    res[q, q] <- dss_p + dss_o + dss_m
+    res[q, beta_sel] <- res[beta_sel, q] <- dbs_o + dbs_m
+    res
 }
 
 

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -414,7 +414,7 @@ objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, si
     sum(invprobit(Xm %*% beta, rho, zetastar, log = TRUE))
 }
 
-grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance) {
+grad_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance) {
   
   imr <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
 
@@ -549,7 +549,7 @@ calculate_skew_correction_factors <- function(y, yo, X, Xm, Xo, fit_beta, fit_si
                             moderate_location = moderate_location,
                             moderate_variance = moderate_variance)
 
-      (abs(diff - offset)/(out_factor/2))^(-1)
+      (abs(diff - offset)/(out_factor / 2))^(-1)
     }
   }, FUN.VALUE = 0.0)
 
@@ -586,9 +586,9 @@ calculate_sigma2_parameters <- function(fit_sigma2, fit_sigma2_var,
                                         variance_prior_scale, variance_prior_df,
                                         moderate_variance, n, p){
 
-  n_approx <- 2 * fit_sigma2^2/fit_sigma2_var
-  rss_approx <- 2 * fit_sigma2^3/fit_sigma2_var
-  s2_approx <- rss_approx/(n_approx - p)
+  n_approx <- 2 * fit_sigma2^2 / fit_sigma2_var
+  rss_approx <- 2 * fit_sigma2^3 / fit_sigma2_var
+  s2_approx <- rss_approx / (n_approx - p)
 
   if(s2_approx < 0 || n_approx <= p){
     df_approx <- 1e-3

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -228,7 +228,7 @@ pd_lm.fit <- function(y, X,
   } else if (method == "numeric") {
     opt_res <- stats::optim(par = c(beta_init, sigma2_init), function(par) {
       beta <- par[beta_sel]
-      sigma2 <- par[p + 1]
+      sigma2 <- par[p+1]
       if (sigma2 <= 0) return (10000)
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
         - objective_fnc(y, yo, X, Xm, Xo,
@@ -245,14 +245,14 @@ pd_lm.fit <- function(y, X,
         
     fit_beta <- opt_res$par[beta_sel]
     coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
-    fit_sigma2 <- opt_res$par[p + 1]
-    fit_sigma2_var <- 1 / opt_res$hessian[p + 1, p + 1]
+    fit_sigma2 <- opt_res$par[p+1]
+    fit_sigma2_var <- 1 / opt_res$hessian[p+1, p+1]
       
   } else if (method == "analytic_grad") {
     # Run optim
     opt_res <- stats::optim(par = c(beta_init, sigma2_init), function(par) {
       beta <- par[beta_sel]
-      sigma2 <- par[p + 1]
+      sigma2 <- par[p+1]
       if (sigma2 <= 0) return(10000)
       zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
       - objective_fnc(y, yo, X, Xm, Xo,
@@ -263,7 +263,7 @@ pd_lm.fit <- function(y, X,
     },
     gr = function(par) {
       beta <- par[beta_sel]
-      sigma2 <- par[p + 1]
+      sigma2 <- par[p+1]
       if (sigma2 <= 0) return(10000)
       zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
       - grad_fnc(y, yo, X, Xm, Xo,
@@ -279,15 +279,15 @@ pd_lm.fit <- function(y, X,
           
       fit_beta <- opt_res$par[beta_sel]
       coef_hessian <- opt_res$hessian[beta_sel, beta_sel, drop = FALSE]
-      fit_sigma2 <- opt_res$par[p + 1]
-      fit_sigma2_var <- 1 / opt_res$hessian[p + 1, p + 1]
+      fit_sigma2 <- opt_res$par[p+1]
+      fit_sigma2_var <- 1 / opt_res$hessian[p+1, p+1]
       
   } else if (method == "analytic_hessian") {
     ## Run nlminb
     nl_res <- nlminb(start = c(beta_init, sigma2_init),
       objective = function(par) {
         beta <- par[beta_sel]
-        sigma2 <- par[p + 1]
+        sigma2 <- par[p+1]
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
         - objective_fnc(y, yo, X, Xm, Xo,
                         beta, sigma2, rho, zetastar,
@@ -297,7 +297,7 @@ pd_lm.fit <- function(y, X,
       },
       gradient = function(par) {
         beta <- par[beta_sel]
-        sigma2 <- par[p + 1]
+        sigma2 <- par[p+1]
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
         - grad_fnc(y, yo, X, Xm, Xo,
                    beta, sigma2, rho, zetastar,
@@ -307,7 +307,7 @@ pd_lm.fit <- function(y, X,
       },
       hessian = function(par) {
         beta <- par[beta_sel]
-        sigma2 <- par[p + 1]
+        sigma2 <- par[p+1]
         zetastar <- zeta * sqrt(1 + sigma2 / zeta ^ 2)
         - hess_fnc(y, yo, X, Xm, Xo,
                    beta, sigma2, rho, zetastar,
@@ -322,7 +322,7 @@ pd_lm.fit <- function(y, X,
     }
       
     fit_beta <- nl_res$par[beta_sel]
-    fit_sigma2 <- nl_res$par[p + 1]
+    fit_sigma2 <- nl_res$par[p+1]
     zetastar <- zeta * sqrt(1 + fit_sigma2 / zeta ^ 2)
     hessian <- - hess_fnc(y, yo, X, Xm, Xo,
                           fit_beta, fit_sigma2, rho, zetastar,
@@ -330,7 +330,7 @@ pd_lm.fit <- function(y, X,
                           variance_prior_df, variance_prior_scale,
                           location_prior_df, moderate_location, moderate_variance,
                           beta_sel, p)
-    fit_sigma2_var <- 1 / hessian[p + 1, p + 1]
+    fit_sigma2_var <- 1 / hessian[p+1, p+1]
     coef_hessian <- hessian[beta_sel, beta_sel, drop = FALSE]
   }
     
@@ -414,79 +414,72 @@ objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, si
     sum(invprobit(Xm %*% beta, rho, zetastar, log = TRUE))
 }
 
-grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, 
-    sigma20, df0, tau20, location_prior_df, moderate_location, 
-    moderate_variance) {
+grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance) {
   
-    imr <- proDA:::inv_mills_ratio(Xm %*% beta, rho, zetastar)
+  im r <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
+
+  if (moderate_location) {
+    Xbmu <- X %*% beta - mu0
+    dbeta_p <- -(location_prior_df + 1) * t(X) %*%(Xbmu / (location_prior_df * sigma20 + Xbmu^2))
+  } else {
+    dbeta_p <- 0
+  }
   
-    if (moderate_location) {
-        Xbmu <- X %*% beta - mu0
-        dbeta_p <- -(location_prior_df + 1) * t(X) %*% 
-            (Xbmu / (location_prior_df * sigma20 + Xbmu^2))
-    } else {
-        dbeta_p <- 0
-    }
-  
-    Xo_t <- t(Xo)
-    dbeta_o <- -(Xo_t %*% Xo %*% beta - Xo_t %*% yo) / sigma2
-    dbeta_m <- t(Xm) %*% imr
+  Xo_t <- t(Xo)
+  dbeta_o <- -(Xo_t %*% Xo %*% beta - Xo_t %*% yo) / sigma2
+  dbeta_m <- t(Xm) %*% imr
   
   
-    if (moderate_variance) {
-        dsig2_p <- -(1 + df0 / 2) / sigma2 + df0 * tau20 / (2 * sigma2 ^ 2) + 
-            1 / sigma2
-    } else {
-        dsig2_p <- 0
-    }
+  if (moderate_variance) {
+    dsig2_p <- -(1 + df0 / 2) / sigma2 + df0 * tau20 / (2 * sigma2 ^ 2) + 1 / sigma2
+  } else {
+    dsig2_p <- 0
+  }
     
-    dsig2_o <- sum(((Xo %*% beta - yo) ^ 2 - sigma2) / (2 * sigma2 ^ 2))
-    dsig2_m <- -sum((Xm %*% beta - rho)/(2 * zetastar ^ 2) * imr)
-    c(dbeta_p + dbeta_o + dbeta_m, dsig2_p + dsig2_o + dsig2_m)
+  dsig2_o <- sum(((Xo %*% beta - yo) ^ 2 - sigma2) / (2 * sigma2 ^ 2))
+  dsig2_m <- -sum((Xm %*% beta - rho)/(2 * zetastar ^ 2) * imr)
+  dbeta_p + dbeta_o + dbeta_m, dsig2_p + dsig2_o + dsig2_m
 }
 
 
-hess_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0,
-    sigma20, df0, tau20, location_prior_df, moderate_location,
-    moderate_variance, beta_sel, p){
+hess_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, 
+                     moderate_location, moderate_variance, beta_sel, p){
     
-    imr <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
+  imr <- inv_mills_ratio(Xm %*% beta, rho, zetastar)
     
-    ## precalculate values
-    zetastar_2 <- zetastar ^ 2
-    zetastar_4 <- zetastar_2 ^ 2
-    Xmbr <- Xm %*% beta - rho
-    X0by0 <- Xo %*% beta - yo
-    q <- p + 1
+  ## precalculate values
+  zetastar_2 <- zetastar ^ 2
+  zetastar_4 <- zetastar_2 ^ 2
+  Xmbr <- Xm %*% beta - rho
+  X0by0 <- Xo %*% beta - yo
+  q <- p+1
     
-    if (moderate_location) {
-        Xbm <- (X %*% beta - mu0) ^ 2
-        t_prior_fact <- (location_prior_df * sigma20 - Xbm) / (location_prior_df * sigma20 + Xbm) ^ 2
-        dbb_p <- -(location_prior_df + 1) * t(X) %*% diag(t_prior_fact, nrow = nrow(X)) %*% X
-    } else {
-        dbb_p <- 0
-    }
-    dbb_o <- -2 * t(Xo) %*% Xo / (2 * sigma2)
-    dbb_m <- - t(Xm) %*% diag(c((imr ^ 2 + Xmbr / zetastar_2 * imr)), nrow(Xm)) %*% Xm
+  if (moderate_location) {
+    Xbm <- (X %*% beta - mu0) ^ 2
+    t_prior_fact <- (location_prior_df * sigma20 - Xbm) / (location_prior_df * sigma20 + Xbm) ^ 2
+    dbb_p <- -(location_prior_df + 1) * t(X) %*% diag(t_prior_fact, nrow = nrow(X)) %*% X
+  } else {
+    dbb_p <- 0
+  }
+  dbb_o <- -2 * t(Xo) %*% Xo / (2 * sigma2)
+  dbb_m <- - t(Xm) %*% diag(c((imr ^ 2 + Xmbr / zetastar_2 * imr)), nrow(Xm)) %*% Xm
 
-    if (moderate_variance) {
-        dss_p <- (1 + df0 / 2)/ (sigma2 ^ 2) - df0 * tau20 / (sigma2 ^ 3) - 1 / sigma2 ^ 2
-    } else {
-        dss_p <- 0
-    }
-    dss_o <- sum((sigma2 - 2 * Xoby0 ^ 2) / (2 * sigma2 ^ 3))
-    dss_m <- sum(Xmbr / (4 * zetastar_4) * imr *
-        (3 - Xmbr * imr - Xmbr ^ 2 / zetastar_2))
+  if (moderate_variance) {
+    dss_p <- (1 + df0 / 2)/ (sigma2 ^ 2) - df0 * tau20 / (sigma2 ^ 3) - 1 / sigma2 ^ 2
+  } else {
+    dss_p <- 0
+  }
+  dss_o <- sum((sigma2 - 2 * Xoby0 ^ 2) / (2 * sigma2 ^ 3))
+  dss_m <- sum(Xmbr / (4 * zetastar_4) * imr * (3 - Xmbr * imr - Xmbr ^ 2 / zetastar_2))
 
-    dbs_o <- t(Xo) %*% X0by0 / sigma2 ^ 2
-    dbs_m <- t(Xm) %*% (Xmbr / (2 * zetastar_2) * imr ^ 2 -
-        (zetastar_2 - Xmbr^2) / (2 * zetastar_4) * imr)
+  dbs_o <- t(Xo) %*% X0by0 / sigma2 ^ 2
+  dbs_m <- t(Xm) %*% (Xmbr / (2 * zetastar_2) * imr ^ 2 - (zetastar_2 - Xmbr^2) / (2 * zetastar_4) * imr)
 
-    res <- matrix(NA, nrow = q, ncol = q)
-    res[beta_sel, beta_sel] <- dbb_p + dbb_o + dbb_m
-    res[q, q] <- dss_p + dss_o + dss_m
-    res[q, beta_sel] <- res[beta_sel, q] <- dbs_o + dbs_m
-    res
+  res <- matrix(NA, nrow = q, ncol = q)
+  res[beta_sel, beta_sel] <- dbb_p + dbb_o + dbb_m
+  res[q, q] <- dss_p + dss_o + dss_m
+  res[q, beta_sel] <- res[beta_sel, q] <- dbs_o + dbs_m
+  res
 }
 
 

--- a/R/pd_lm.R
+++ b/R/pd_lm.R
@@ -395,20 +395,20 @@ pd_lm.fit <- function(y, X,
 }
 
 
-objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, sigma20, df0, tau20, location_prior_df, moderate_location, moderate_variance){
-  val <- 0
-  if(moderate_location){
-    val <- val + sum(dt.scaled(X %*% beta, df=location_prior_df, mean= mu0, sd=sqrt(sigma20), log=TRUE))
-  }
-  if(moderate_variance){
-    val <- val +
-      extraDistr::dinvchisq(sigma2, df0, tau20, log=TRUE) +
-      log(sigma2)   # important to remove the implicit 1/sigma2 prior in the Inv-Chisq distr
-  }
-  val <- val +
-    sum(dnorm(Xo %*% beta, yo, sd=sqrt(sigma2), log=TRUE)) +
-    sum(invprobit(Xm %*% beta, rho, zetastar, log=TRUE))
-  val
+objective_fnc <- function(y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, 
+    sigma20, df0, tau20, location_prior_df, moderate_location, 
+    moderate_variance) {
+    val <- 0
+    if (moderate_location) {
+        val <- sum(dt.scaled(X %*% beta, df = location_prior_df, 
+            mean = mu0, sd = sqrt(sigma20), log = TRUE))
+    }
+    if (moderate_variance) {
+        val <- val + extraDistr::dinvchisq(sigma2, df0, tau20, log = TRUE) + 
+            log(sigma2)
+    }
+    val + sum(dnorm(Xo %*% beta, yo, sd = sqrt(sigma2), log = TRUE)) + 
+        sum(invprobit(Xm %*% beta, rho, zetastar, log = TRUE))
 }
 
 grad_fnc <- function (y, yo, X, Xm, Xo, beta, sigma2, rho, zetastar, mu0, 

--- a/R/stats_functions.R
+++ b/R/stats_functions.R
@@ -2,13 +2,14 @@
 
 
 
-dt.scaled <- function(x, df, mean=0, sd=1, log=FALSE){
-  res <- dt((x-mean)/sd, df=df, log=log)
-  if(log){
-    res - log(sd)
-  }else{
-    res * 1/sd
-  }
+dt.scaled <- function (x, df, mean = 0, sd = 1, log = FALSE) {
+    res <- dt((x - mean) / sd, df = df, log = log)
+    if (log) {
+        res - log(sd)
+    }
+    else {
+        res / sd
+    }
 }
 
 

--- a/R/stats_functions.R
+++ b/R/stats_functions.R
@@ -3,13 +3,12 @@
 
 
 dt.scaled <- function (x, df, mean = 0, sd = 1, log = FALSE) {
-    res <- dt((x - mean) / sd, df = df, log = log)
-    if (log) {
-        res - log(sd)
-    }
-    else {
-        res / sd
-    }
+  res <- dt((x - mean) / sd, df = df, log = log)
+  if (log) {
+    res - log(sd)
+  } else {
+    res / sd
+  }
 }
 
 


### PR DESCRIPTION
Hi @const-ae 

I had a look on  the `lm_pd.fit` function, since it seems this causes the speed limitations (it is called several times in the function `fit_parameters_loop`, especially in `lapply`). By itself, the function is very fast and I don't think we can speed it up much more (especially the optimization functions that are already written in C). 

I found some minor issues that make it slightly faster, maybe in the sum then it will run a bit faster (at least my `microbenchmark` checks showed some improvement in computation time). 

I was also thinking of parallelizing the `lapply` that uses the `lm_pd.fit`, but so far it seems making up the cluster takes more time (since every fitting by `lm_pd.fit` is quite fast), maybe chunking will help but I will have a look on this.
